### PR TITLE
Use WIN32OLE to resolve networkadapter_product

### DIFF
--- a/lib/facter/networkadapter_product.rb
+++ b/lib/facter/networkadapter_product.rb
@@ -1,10 +1,12 @@
 Facter.add(:networkadapter_product) do
   confine :operatingsystem => :windows
   setcode do
+    require 'win32ole'
     result = ''
     # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394216(v=vs.85).aspx
-    query = 'select * from Win32_NetworkAdapter where AdapterTypeId=0 and (NetConnectionStatus=1 or NetConnectionStatus=2)'
-    Facter::Util::WMI.execquery(query).each do |adapter|
+    wmi = WIN32OLE.connect('winmgmts://./root/CIMV2')
+    query = wmi.ExecQuery('select * from Win32_NetworkAdapter where AdapterTypeId=0 and (NetConnectionStatus=1 or NetConnectionStatus=2)')
+    query.each do |adapter|
       result = adapter.ProductName
       break
     end


### PR DESCRIPTION
Previously the networkadapter_product fact used the Facter::Util::WMI
API to resolve the value, but that API is no longer available in Facter
3.

This commit modifies the fact to use WIN32OLE instead, as is done with
other WMI based facts in this module. The WIN32OLE API is provided by
Ruby so it isn't sensitive to facter versions.

Fixes #3.