### PR TITLE
Fix for UTF-8 error on Puppet 4

### DIFF
--- a/lib/facter/monitor_description.rb
+++ b/lib/facter/monitor_description.rb
@@ -6,7 +6,7 @@ Facter.add(:monitor_description) do
     wmi = WIN32OLE.connect('winmgmts://./root/CIMV2')
     query = wmi.ExecQuery('select Description from Win32_DesktopMonitor')
     query.each do |monitor|
-      result = monitor.Description
+      result = monitor.Description.encode(Encoding.find('UTF-8'), {invalid: :replace, undef: :replace, replace: ''})
       break
     end
     result

--- a/lib/facter/soundcard_description.rb
+++ b/lib/facter/soundcard_description.rb
@@ -6,7 +6,7 @@ Facter.add(:soundcard_description) do
     wmi = WIN32OLE.connect('winmgmts://./root/CIMV2')
     query = wmi.ExecQuery('select Description from Win32_SoundDevice')
     query.each do |device|
-      result = device.Description
+      result = device.Description.encode(Encoding.find('UTF-8'), {invalid: :replace, undef: :replace, replace: ''})
       break
     end
     result    

--- a/lib/facter/soundcard_manufacturer.rb
+++ b/lib/facter/soundcard_manufacturer.rb
@@ -6,7 +6,7 @@ Facter.add(:soundcard_manufacturer) do
     wmi = WIN32OLE.connect('winmgmts://./root/CIMV2')
     query = wmi.ExecQuery('select Manufacturer from Win32_SoundDevice')
     query.each do |device|
-      result = device.Manufacturer
+      result = device.Manufacturer.encode(Encoding.find('UTF-8'), {invalid: :replace, undef: :replace, replace: ''})
       break
     end
     result

--- a/lib/facter/videocard_description.rb
+++ b/lib/facter/videocard_description.rb
@@ -6,7 +6,7 @@ Facter.add(:videocard_description) do
     wmi = WIN32OLE.connect('winmgmts://./root/CIMV2')
     query = wmi.ExecQuery('select Description from Win32_VideoController')
     query.each do |controller|
-      result = controller.Description
+      result = controller.Description.encode(Encoding.find('UTF-8'), {invalid: :replace, undef: :replace, replace: ''})
       break
     end
     result   


### PR DESCRIPTION
The soundcard custom fact may cause issues on _some_ hosts with non-english locale:

> 2016-12-27 17:38:43,366 ERROR [puppetserver] Puppet Server Error: invalid byte sequence in UTF-8

The fact value that caused this error in the first place:

>   soundcard_description: High Definition Audio-Gerät
>   soundcard_manufacturer: Microsoft

My patch ensures that these facts are always converted to UTF-8.